### PR TITLE
configure panel; Easier to config ElevenLabs, choose default engine

### DIFF
--- a/presets.json
+++ b/presets.json
@@ -1,6 +1,6 @@
 {
     "Random Any": {
-        "engine": "Windows TTS",
+        "engine": "any",
         "BaseTTSConfig": {
             "voice_name": [
                 "random",
@@ -10,7 +10,7 @@
         }
     },
     "Random Female": {
-        "engine": "Windows TTS",
+        "engine": "any",
         "BaseTTSConfig": {
             "voice_name": [
                 "random",
@@ -20,7 +20,7 @@
         }
     },
     "Random Male": {
-        "engine": "Windows TTS",
+        "engine": "any",
         "BaseTTSConfig": {
             "voice_name": [
                 "random",
@@ -30,7 +30,7 @@
         }
     },
     "Clockwork": {
-        "engine": "Windows TTS",
+        "engine": "any",
         "BaseTTSConfig": {
             "voice_name": [
                 "random",
@@ -59,7 +59,7 @@
         }
     },
     "Vahzilok": {
-        "engine": "Windows TTS",
+        "engine": "any",
         "BaseTTSConfig": {
             "voice_name": [
                 "random",
@@ -77,7 +77,7 @@
         }
     },
     "Circle of Thorns": {
-        "engine": "Windows TTS",
+        "engine": "any",
         "BaseTTSConfig": {
             "voice_name": [
                 "random",

--- a/src/coh_npc_voices/effects.py
+++ b/src/coh_npc_voices/effects.py
@@ -953,8 +953,8 @@ class Delay(EffectParameterEditor):
             default=0.5,
             from_=-0.1,
             to=1,
-            digits=2,
-            resolution=0.1
+            digits=3,
+            resolution=0.01
         ).pack(side='top', fill='x', expand=True)
 
         LScale(

--- a/src/coh_npc_voices/effects.py
+++ b/src/coh_npc_voices/effects.py
@@ -7,7 +7,6 @@ import numpy as np
 import pedalboard
 import voicebox
 from sqlalchemy import select
-import settings
 
 log = logging.getLogger('__name__')
 

--- a/src/coh_npc_voices/engines.py
+++ b/src/coh_npc_voices/engines.py
@@ -72,7 +72,8 @@ class TTSEngine(tk.Frame):
 
     def say(self, message, effects, sink=None, *args, **kwargs):
         tts = self.get_tts()
-        log.info('tts: %s', tts)
+        log.info(f'{self}.say({message=}, {effects=}, {sink=}, {args=}, {kwargs=}')
+        log.info(f'Invoking voicebox.SimpleVoicebox({tts=}, {effects=}, {sink=})')
         vb = voicebox.SimpleVoicebox(
             tts=tts,
             effects=effects, 
@@ -414,6 +415,7 @@ class GoogleCloud(TTSEngine):
 
     @staticmethod
     def get_voice_names(language_code="en-US", gender=None):
+        log.info(f'get_voice_names({language_code=}, {gender=})')
         with models.Session(models.engine) as session:
             all_voices = list(
                 session.execute(
@@ -426,6 +428,14 @@ class GoogleCloud(TTSEngine):
             if all_voices:
                 log.info(f"{len(all_voices)} voices found in database")
                 if gender:
+                    out = []
+                    for result in all_voices:
+                        if result.ssml_gender.upper() == gender.upper():
+                            out.append(result.name)
+                        else:
+                            log.info(f'{gender} != {result.ssml_gender}')
+                    return out
+                
                     return [
                         voice.name
                         for voice in all_voices
@@ -469,14 +479,14 @@ class GoogleCloud(TTSEngine):
         kwargs = {
             "language_code": self.language_code.get(),
             "name": self.voice_name.get(),
-            "ssml_gender": self.ssml_gender.get(),
+            # "ssml_gender": self.ssml_gender.get(),
         }
 
         audio_config = texttospeech.AudioConfig(
             speaking_rate=float(self.rate.get()), pitch=float(self.pitch.get())
         )
 
-        log.debug("texttospeech.VoiceSelectionParams(%s)" % kwargs)
+        log.info("texttospeech.VoiceSelectionParams(%s)" % kwargs)
         voice_params = texttospeech.VoiceSelectionParams(
             **kwargs
             # texttospeech.SsmlVoiceGender.NEUTRAL

--- a/src/coh_npc_voices/settings.py
+++ b/src/coh_npc_voices/settings.py
@@ -58,3 +58,11 @@ def save_config(config):
 def get_config_key(key, default=None):
     config = get_config()
     return config.get(key, default)
+
+ALL_NPC = {}
+def get_npc_data(character_name):
+    global ALL_NPC
+    if not ALL_NPC:
+        with open("all_npcs.json", "r") as h:
+            ALL_NPC = json.loads(h.read())
+    return ALL_NPC.get(character_name)

--- a/src/coh_npc_voices/settings.py
+++ b/src/coh_npc_voices/settings.py
@@ -5,6 +5,7 @@ import json
 import os
 
 LOGLEVEL=logging.INFO 
+# this is the ultimate fallback engine if there is nothing configured
 DEFAULT_ENGINE="Windows TTS"
 
 PRESETS = "presets.json"

--- a/src/coh_npc_voices/voice_builder.py
+++ b/src/coh_npc_voices/voice_builder.py
@@ -26,6 +26,15 @@ class tkvar_ish:
 def apply_preset(character_name, character_category, preset_name, gender=None):
     preset = PRESETS.get(GROUP_ALIASES.get(preset_name, preset_name))
     
+    if gender is None:
+        # get gender for preset in most circumstances
+        npc_data = settings.get_npc_data(character_name)
+        if npc_data:
+            if npc_data["gender"] == "GENDER_MALE":
+                gender = "male"
+            elif npc_data["gender"] == "GENDER_FEMALE":
+                gender = "female"            
+
     if preset is None:
         log.info(f'No preset is available for {preset_name}')
         add_group_alias_stub(preset_name)

--- a/src/coh_npc_voices/voice_builder.py
+++ b/src/coh_npc_voices/voice_builder.py
@@ -1,14 +1,13 @@
 import logging
 import os
 import re
-import datetime
 import effects
 import random
 import models
 import engines
 from pedalboard.io import AudioFile
 from voicebox.sinks import Distributor, SoundDevice, WaveFile
-from sqlalchemy import delete, select, update
+from sqlalchemy import delete, select
 from npc import PRESETS, GROUP_ALIASES, add_group_alias_stub
 import settings
 
@@ -39,7 +38,17 @@ def apply_preset(character_name, character_category, preset_name, gender=None):
             character_category,
             session=session
         )
-        character.engine = preset['engine']
+       
+        if character_category == 2:
+            default = settings.get_config_key('DEFAULT_PLAYER_ENGINE')
+        else:
+            default = settings.get_config_key('DEFAULT_ENGINE')
+
+        if preset['engine'] == 'any':
+            character.engine = default
+        else:
+            character.engine = preset['engine']
+
         session.commit()
         
         for model in ("BaseTTSConfig", "Effects"):
@@ -74,6 +83,7 @@ def apply_preset(character_name, character_category, preset_name, gender=None):
                 if choice == "random":
                     if gender == "any":
                         gender = None
+                    
 
                     all_available_names = engines.get_engine(
                         character.engine
@@ -144,6 +154,7 @@ def create(character, message, cachefile):
     2. Render message based on that data
     3. persist as an mp3 in cachefile
     """
+    log.info(f'voice_builder.create({character=}, {message=}, {cachefile=})')
     with models.Session(models.engine) as session:
         voice_effects = session.scalars(
             select(models.Effects).where(
@@ -205,14 +216,6 @@ def create(character, message, cachefile):
     
     selected_name = tkvar_ish(f"{character.cat_str()} {character.name}")
     engines.get_engine(character.engine)(None, selected_name).say(message, effect_list, sink=sink)
-
-    with models.Session(models.engine) as session:
-        session.execute(
-            update(models.Character).values(
-                last_spoke=datetime.datetime.now()
-            )
-        )
-        session.commit()
 
     if save:
         with AudioFile(cachefile + ".wav") as input:

--- a/src/coh_npc_voices/voice_editor.py
+++ b/src/coh_npc_voices/voice_editor.py
@@ -786,7 +786,8 @@ class ListSide(tk.Frame):
                 select(
                     models.Character
                 ).order_by(
-                    models.Character.last_spoke.desc()
+                    models.Character.category,
+                    models.Character.last_spoke
                 )
             ).all()
 


### PR DESCRIPTION
Some solid bug fixes in here, new feature is a top level panel for configuration.  I'll gradually move more of the internal toggles out to it.  For now it lets you decide what the default engine should be for both NPC and Player voices and lets you normalize them by default to get a consistent voice volume across multiple sources.

Default is still to use free local Windows TTS.  Quality isn't very good but the price is right.