### PR TITLE
minor old code cleanup, announce speaker, speak supergroup, speak lea…

### DIFF
--- a/cnv/chatlog/npc_chatter.py
+++ b/cnv/chatlog/npc_chatter.py
@@ -445,6 +445,16 @@ class LogStream:
     # what channels are we paying attention to, which self.parser function is
     # going to be called to properly extract the data from that log entry.
     channel_guide = {
+        'SuperGroup': {
+            'enabled': settings.get_config_key('Speak SuperGroup', True),
+            'name': "player",
+            'parser': 'channel_chat_parser'
+        },
+        'League': {
+            'enabled': settings.get_config_key('Speak League', True),
+            'name': "player",
+            'parser': 'channel_chat_parser'
+        },
         'NPC': {
             'enabled': settings.get_config_key('Speak NPC', True),
             'name': "npc",
@@ -477,9 +487,9 @@ class LogStream:
         logdir: str,
         speaking_queue: queue.Queue,
         event_queue: queue.Queue,
-        badges: bool,
-        npc: bool,
-        team: bool,
+        # badges: bool,
+        # npc: bool,
+        # team: bool,
     ):
         """
         find the most recent logfile in logdir note which file it is, open it,
@@ -488,13 +498,6 @@ class LogStream:
         start tailing.
         """
         self.logdir = logdir
-        self.announce_badges = badges
-        # TODO: these should be exposed on the configuration page
-        self.npc_speak = npc
-        self.team_speak = team
-        self.tell_speak = True
-        self.caption_speak = True
-        self.announce_levels = True
         self.hero = None
         # who is (as far as we know) currently speaking as CAPTION ?
         self.caption_speaker = None
@@ -729,6 +732,11 @@ class LogStream:
                 # log.info(f"Speaking: [{channel}] {speaker}: {dialog}")
                 # speaker name, spoken dialog, channel (npc, system, player)
                 log.debug(f"Speaking: {speaker}, {dialog}, {guide['name']}")
+                
+                if settings.get_config_key('Announce Speaker', False):
+                    # self-announce?  lets try it..
+                    dialog = f"{speaker} says, {dialog}"
+
                 self.speaking_queue.put((speaker, dialog, guide['name']))
             else:
                 log.debug('Not speaking: %s', lstring)
@@ -1282,13 +1290,13 @@ class LogStream_old:
         start tailing.
         """
         self.logdir = logdir
-        self.announce_badges = badges
+        # self.announce_badges = badges
         # TODO: these should be exposed on the configuration page
-        self.npc_speak = npc
-        self.team_speak = team
-        self.tell_speak = True
-        self.caption_speak = True
-        self.announce_levels = True
+        # self.npc_speak = npc
+        # self.team_speak = team
+        # self.tell_speak = True
+        # self.caption_speak = True
+        # self.announce_levels = True
         self.hero = None
         # who is (as far as we know) currently speaking as CAPTION ?
         self.caption_speaker = None
@@ -1702,7 +1710,7 @@ Ten missions, ends in fight against AV Vandal'''
                             log.debug('Returned from channel_messager()')
                             continue
 
-                        elif self.announce_badges and lstring[0] == "Congratulations!":
+                        elif settings.get_toggle(settings.taggify("Speak Badges")) and lstring[0] == "Congratulations!":
                             self.ssay(" ".join(lstring[4:]))
 
                         elif lstring[0] == "You":

--- a/cnv/lib/settings.py
+++ b/cnv/lib/settings.py
@@ -72,6 +72,7 @@ def get_config(cf="config.json"):
         mtime = os.path.getmtime(cf)
         if CACHE_CONFIG_MTIME.get(cf) is None or mtime != CACHE_CONFIG_MTIME[cf]:
             with open(cf) as h:
+                log.info("(re)loading config from %s", cf)
                 try:
                     config = json.loads(h.read())
                 except json.decoder.JSONDecodeError:
@@ -97,9 +98,11 @@ def set_config_key(key, value, cf="config.json"):
 def save_config(config, cf="config.json"):
     global CACHE_CONFIG
     global CACHE_CONFIG_MTIME
+
+    CACHE_CONFIG[cf] = config
+
     with open(cf, "w") as h:
-        h.write(json.dumps(config, indent=4, sort_keys=True))
-        CACHE_CONFIG[cf] = config
+        h.write(json.dumps(config, indent=4, sort_keys=True))   
         CACHE_CONFIG_MTIME[cf] = os.path.getmtime(cf)
 
 

--- a/cnv/tabs/character.py
+++ b/cnv/tabs/character.py
@@ -548,12 +548,8 @@ class ChatterService:
 
         logdir = settings.log_dir()
 
-        badges = True
-        team = True
-        npc = True
-
         ls = npc_chatter.LogStream(
-            logdir, speaking_queue, event_queue, badges, npc, team
+            logdir, speaking_queue, event_queue
         )
         
         # while True:

--- a/cnv/tabs/configuration.py
+++ b/cnv/tabs/configuration.py
@@ -12,6 +12,7 @@ log = logging.getLogger(__name__)
 
 TOGGLES = [
     ("Acknowledge each win", "on"),
+    ("Announce Speaker", "off"),
     ("Persist player chat", "on"),
     ("Speak Buffs", "on"),
     ("Speak Debuffs", "on"),
@@ -26,6 +27,8 @@ TOGGLES = [
     ("Speak Local", "on"),
     ("Speak Captions", "on"),
     ("Speak Team", "on"),
+    ("Speak SuperGroup", "on"),
+    ("Speak League", "on"),
     ("Speak Tell", "on"),
     ("Speak NPC", "on"),
 ]

--- a/cnv/tabs/logview.py
+++ b/cnv/tabs/logview.py
@@ -28,12 +28,8 @@ class ChatterService:
 
         logdir = settings.log_dir()
 
-        badges = True
-        team = True
-        npc = True
-
         ls = npc_chatter.LogStream(
-            logdir, speaking_queue, event_queue, badges, npc, team
+            logdir, speaking_queue, event_queue
         )
         
         # while True:


### PR DESCRIPTION
Added some requested features.

The toggles are not working correctly; specifically they are intended to be "hot" meaning you can turn them on and off during a session and they should immediately enabled/disable.  That does not work.  Setting them then reloading sidekick _does_ appear to work.

I'm not _really_ surprised, the toggles UI is in one process and the speaking is in another.  The speaker process is supposed to notice when the config file mtime changes and re-load it but that doesn't seem to be happening.

In any  case, you can enable/disable supergroup voices and league voices, and you can enable "Announce Speaker" which prefixes "Jimbob says X".  It may need some more refinement.

I'll cut a new release to make sure that whole process is still working, it has been a while.